### PR TITLE
throw error when error occures

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,8 @@ function restMiddlewareCreator (customConfig) {
         console.log('err')
         console.log(err)
         // Request failure, dispatch the error
-        dispatch({ type: `${type}_${FAILURE}`, err, meta: resultMeta })
+        dispatch({ type: `${type}_${FAILURE}`, err, meta: resultMeta });
+        throw err;
       })
   }
 }


### PR DESCRIPTION
throw error if error occurs in order to respect promise standards